### PR TITLE
Corrigindo link dos repos

### DIFF
--- a/src/components/repositories/index.js
+++ b/src/components/repositories/index.js
@@ -46,7 +46,7 @@ const Repositories = () => {
                 <RepositoryItem
                   key={item.id}
                   name={item.name}
-                  linkToRepo={item.full_name}
+                  linkToRepo={item.html_url}
                   fullName={item.full_name}
                 />
               ))}


### PR DESCRIPTION
Corrigindo link fullname para reposirório correspondente no github :)
Erro: o link do fullname estava retornando a mesma página, não o repositório do usuário correspondente no github :(
Correção: Ao clicar no fullname  ele irá direcionar para o repositório no github do usuário ;)